### PR TITLE
Update `quickcheck-lockstep` dependency to `>= 0.2.0`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,8 +5,3 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/haskell-lmdb
   tag: fe5d3e54a3b3a683c8ec8712abb160561a676b4a
-
-source-repository-package
-  type: git
-  location: https://github.com/well-typed/quickcheck-lockstep
-  tag: 4f7a59988561691e79d592f2417d244539f607fc

--- a/lmdb-simple.cabal
+++ b/lmdb-simple.cabal
@@ -72,7 +72,7 @@ test-suite test-cursors
                      , mtl
                      , QuickCheck
                      , quickcheck-dynamic
-                     , quickcheck-lockstep
+                     , quickcheck-lockstep >= 0.2
                      , serialise
                      , tasty
                      , tasty-hunit


### PR DESCRIPTION
This removes the need for a `source-repository-packages` entry in the `cabal.project` file.