### PR TITLE
`cardano-lmdb-simple-0.5.0.0`

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
 
 permissions:
   contents: read
@@ -12,52 +11,65 @@ permissions:
 jobs:
   build:
 
+    runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       matrix:
         ghc: ["8.10.7", "9.2.5"]
         cabal: ["3.8.1.0"]
-        os: [ubuntu-latest] # TODO: add Windows CI
-
-    runs-on: ${{ matrix.os }}
+        os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Workaround runner image issue
+      if: runner.os == 'Linux'
+      # https://github.com/actions/runner-images/issues/7061
+      run: sudo chown -R $USER /usr/local/.ghcup
 
-    - name: Setup Haskell
-      uses: haskell/actions/setup@v2
-      with:
-        ghc-version: '8.10.7'
-        cabal-version: '3.6.2.0'
+    - name: Checkout repository
+      uses: actions/checkout@v3
 
-    - name: Cache
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-cabal
-      with:
-        path: ~/.cabal
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-
-    - name: Install system dependencies
+    - name: "LINUX: Install build environment (apt-get)"
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
         sudo apt-get -y install liblmdb-dev
+        sudo apt-get -y autoremove
 
-    - name: Install Cabal dependencies
+    - name: Setup Haskell
+      id: setup-haskell
+      uses: haskell/actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+        cabal-update: false
+
+    - name: Cabal update
+      run: cabal update
+
+    - name: Record cabal dependencies
+      id: record-deps
       run: |
-        cabal update
-        cabal build --only-dependencies --enable-tests --enable-benchmarks
+        cabal build all --dry-run
+
+    - name: Cache cabal store
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-cabal
+      with:
+        path: ${{ steps.setup-haskell.outputs.cabal-store }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-${{ matrix.ghc }}-build-
+          ${{ runner.os }}-${{ matrix.ghc }}-
+          ${{ runner.os }}-
+
+    - name: Install cabal dependencies
+      run: cabal build --only-dependencies --enable-tests --enable-benchmarks all
 
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks all
 
     - name: Run tests
       run: cabal test all
-
-    - name: Run benchmarks
-      run: cabal bench bench

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,25 @@
 
 First release of `lmdb-simple` fork. See
 [INPUT-OUTPUT-FORK.md](./INPUT-OUTPUT-FORK.md).
+
+This changelog describes changes from revision
+`9ffca8a30489e7f0aafd77cf73374979c27eb97d` onwards, which include all changes
+introduced by the Consensus team.
+
+### Non-Breaking
+
+- Expose the `Database.LMDB.Simple.Internal` module.
+- Add a monadic cursor API that provides fine-grained access to cursors. This
+  new API lives in `Database.LDMB.Simpel.Cursor`.
+- Add a blocking version of closing LMDB environments.
+- Expose `marshalOutBS`, `copyLazyBS` and `pokeMDBVal` from
+  `Database.LMDB.Simple.Internal`.
+- Add `pokeMDBVal` counterpart to `peekMDBVal`.
+- Add `putNoOverwrite` function that is similar to `put`, but disallows
+  overwrites.
+
+### Breaking
+
+- Rename package from `lmdb-simple` to `cardano-lmdb-simple`.
+- `copyLazyBS` throws an error if the copy is incomplete.
+- Rename `peekVal` to `peekMDBVal`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+
+<a id='changelog-0.5.0.0'></a>
+## 0.5.0.0 — 2023-02-17
+
+First release of `lmdb-simple` fork. See
+[INPUT-OUTPUT-FORK.md](./INPUT-OUTPUT-FORK.md).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+See the [code of conduct file in the Cardano engineering handbook](https://github.com/input-output-hk/cardano-engineering-handbook/blob/main/CODE-OF-CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+See [the contributing file in the `ouroboros-network` repository](
+https://github.com/input-output-hk/ouroboros-network/blob/master/CONTRIBUTING.md).
+We follow consensus guidelines where consensus and network diverge.

--- a/INPUT-OUTPUT-FORK.md
+++ b/INPUT-OUTPUT-FORK.md
@@ -9,5 +9,10 @@ Consensus team at Input-Output Global uses forks of the `lmdb` and `lmdb-simple`
 packages for developing a state-of-the-art storage component. Since it has
 become policy to no longer rely on `source-repository-package` stanzas in
 Cardano projects, we publish our forks to CHaP under the names `cardano-lmdb`
-and `cardano-lmdb-simple`. If time and opportunity permits, we would try
-upstreaming our contributions to the main repository.
+and `cardano-lmdb-simple`. Furthermore, the Consensus codebase favours explicit
+CBOR encoding/decoding instead of using `Serialise` type class instances, which
+is largely incompatible with `lmdb-simple` because `lmdb-simple` has `Serialise`
+constraints everywhere. Finally, we provide more fine-grained access to cursors
+in this fork, which is also required by the Consensus storage component. If time
+and opportunity permits, we would try upstreaming our contributions to the main
+repository.

--- a/INPUT-OUTPUT-FORK.md
+++ b/INPUT-OUTPUT-FORK.md
@@ -1,0 +1,13 @@
+# Reasons for the fork
+
+Here we expose the reasons for the Input Output Global fork `lmdb-simple`.
+
+A dedicated Hackage instance called [Cardano Haskell Packages
+(CHaP)](https://github.com/input-output-hk/cardano-haskell-packages) exists for
+Haskell packages that are primarily used within the Cardano ecosystem. The
+Consensus team at Input-Output Global uses forks of the `lmdb` and `lmdb-simple`
+packages for developing a state-of-the-art storage component. Since it has
+become policy to no longer rely on `source-repository-package` stanzas in
+Cardano projects, we publish our forks to CHaP under the names `cardano-lmdb`
+and `cardano-lmdb-simple`. If time and opportunity permits, we would try
+upstreaming our contributions to the main repository.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
+[![Haskell CI](https://img.shields.io/github/actions/workflow/status/input-output-hk/lmdb-simple/haskell.yml?label=Build&style=for-the-badge)](https://github.com/input-output-hk/lmdb-simple/actions/workflows/haskell.yml)
+[![handbook](https://img.shields.io/badge/policy-Cardano%20Engineering%20Handbook-informational?style=for-the-badge)](https://input-output-hk.github.io/cardano-engineering-handbook)
 
-Simple Haskell API for LMDB
-===========================
+# Input-Ouptut fork lmdb-simple
+
+See [INPUT-OUTPUT-FORK.md](./INPUT-OUPUT-FORK.md) for reasons for the current
+fork.
+
+We follow processes and guidelines as established by the Consensus team at IOG.
+A nice starting point for reading `ouroboros-consensus` documentation is
+[ouroboros-network/ouroboros-consensus/README.md](
+https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/README.md).
+
+# Simple Haskell API for LMDB
 
 This package allows you to store arbitrary Haskell values in and retrieve them
 from a persistent [Lightning Memory-mapped Database][LMDB] on disk.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,4 @@
+See the [consensus release process file in the `ouroboros-network`
+repository](https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/docs/ReleaseProcess.md).
+Note that we do not do any bundling of packages: each package has its own
+changelog, and each can be released separately.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,1 @@
+See the [security file in the Cardano engineering handbook](https://github.com/input-output-hk/cardano-engineering-handbook/blob/main/SECURITY.md).

--- a/cabal.project
+++ b/cabal.project
@@ -4,4 +4,4 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/haskell-lmdb
-  tag: 08e5c1572e98e599d60bb24a7b2569879a35a7b1
+  tag: ad0a93ac52f06ba7ac67774f99e82b000e843432

--- a/cabal.project
+++ b/cabal.project
@@ -11,8 +11,3 @@ repository cardano-haskell-packages
 
 packages:
   .
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/haskell-lmdb
-  tag: ad0a93ac52f06ba7ac67774f99e82b000e843432

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,14 @@
+repository cardano-haskell-packages
+  url: https://input-output-hk.github.io/cardano-haskell-packages
+  secure: True
+  root-keys:
+    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
+    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
+    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
+    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
+    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
+    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
+
 packages:
   .
 

--- a/cardano-lmdb-simple.cabal
+++ b/cardano-lmdb-simple.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
-name:                lmdb-simple
-version:             0.4.0.0
+name:                cardano-lmdb-simple
+version:             0.5.0.0
 synopsis:            Simple API for LMDB
 description:         This package provides a simple API for using the
                      Lightning Memory-mapped Database (LMDB).
@@ -39,7 +39,7 @@ library
                      , bytestring >= 0.10 && < 0.12
                      , containers
                      , exceptions
-                     , lmdb >= 0.2 && < 0.3
+                     , cardano-lmdb >= 0.3.0.0
                      , mtl
                      , serialise >= 0.2 && < 0.3
                      , unliftio-core
@@ -57,11 +57,11 @@ test-suite test-cursors
                        Test.Database.LMDB.Simple.Cursor.Lockstep
                        Test.Database.LMDB.Simple.Cursor.Lockstep.Mock
   build-depends:       base
+                     , cardano-lmdb
+                     , cardano-lmdb-simple
                      , containers
                      , directory
                      , exceptions
-                     , lmdb
-                     , lmdb-simple
                      , mtl
                      , QuickCheck
                      , quickcheck-dynamic
@@ -83,10 +83,10 @@ benchmark bench
                        Bench.Utils
   build-depends:       base
                      , bytestring
+                     , cardano-lmdb-simple
                      , containers
                      , deepseq
                      , directory
-                     , lmdb-simple
                      , QuickCheck
                      , random
                      , serialise
@@ -103,7 +103,7 @@ test-suite sample
   hs-source-dirs:      test
   main-is:             sample.hs
   build-depends:       base
-                     , lmdb-simple
+                     , cardano-lmdb-simple
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 
@@ -116,7 +116,7 @@ test-suite hspec
                        Harness
   build-depends:       base
                      , hspec
-                     , lmdb-simple
+                     , cardano-lmdb-simple
                      , QuickCheck
   build-tool-depends:  hspec-discover:hspec-discover
   ghc-options:         -Wall -Wno-unused-do-bind
@@ -130,7 +130,7 @@ benchmark criterion
   other-modules:       Harness
   build-depends:       base
                      , criterion
-                     , lmdb-simple
+                     , cardano-lmdb-simple
   ghc-options:         -Wall -Wno-name-shadowing
                        -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,0 +1,13 @@
+[scriv]
+format = md
+# insert_marker = Changelog entries
+md_header_level = 2
+version = literal: ./cardano-lmdb-simple.cabal: version
+categories = Patch, Non-Breaking, Breaking
+end_marker = scriv-end-here
+fragment_directory = ./changelog.d
+ghrel_template = {{body}}
+main_branches = master, main, develop
+new_fragment_template = file: new_fragment.${config:format}.j2
+output_file = ./CHANGELOG.${config:format}
+skip_fragments = README.*


### PR DESCRIPTION
We prepare to publish `cardano-lmdb-simple-0.5.0.0` to [CHaP](https://github.com/input-output-hk/cardano-haskell-packages). To make this forked package ready for publication, we follow the steps in the [Cardano Engineering Handbook](https://input-output-hk.github.io/cardano-engineering-handbook/introduction.html), which includes setting up CI (currently only for Linux: #6) and adding documentation.