### PR TITLE
Make cursor monad preserve transaction mode.

### DIFF
--- a/changelog.d/20230217_144946_joris_cursor_preserves_transaction_mode.md
+++ b/changelog.d/20230217_144946_joris_cursor_preserves_transaction_mode.md
@@ -3,23 +3,17 @@ A new scriv changelog fragment.
 
 Uncomment the section that is right (remove the HTML comment wrapper).
 -->
-
-
+<!--
 ### Patch
 
-- Annotate cursor monads with transaction modes. This prevents read-write cursor
-  operations from running in read-only environments.
-
-
+-->
 <!--
 ### Non-Breaking
 
 - A bullet item for the Non-Breaking category.
 
 -->
-<!--
 ### Breaking
 
-- A bullet item for the Breaking category.
-
--->
+- Annotate cursor monads with transaction modes. This prevents read-write cursor
+  operations from running in read-only environments.

--- a/changelog.d/20230217_144946_joris_cursor_preserves_transaction_mode.md
+++ b/changelog.d/20230217_144946_joris_cursor_preserves_transaction_mode.md
@@ -1,0 +1,25 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+
+### Patch
+
+- Annotate cursor monads with transaction modes. This prevents read-write cursor
+  operations from running in read-only environments.
+
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/src/Database/LMDB/Simple/Cursor.hs
+++ b/src/Database/LMDB/Simple/Cursor.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneKindSignatures   #-}
 
 module Database.LMDB.Simple.Cursor (
     -- * The Cursor monad
@@ -61,6 +62,7 @@ import           Codec.Serialise
 import           Control.Monad.Catch
 import           Control.Monad.Reader
 import           Data.Foldable
+import           Data.Kind
 import           Data.Map.Strict               (Map)
 import qualified Data.Map.Strict               as Map
 import           Foreign                       (Ptr, alloca, nullPtr)
@@ -114,13 +116,20 @@ data PeekPoke k v = PeekPoke {
 -- We perform lower-level cursor operations in @'IO'@, while the @'ReaderT'@
 -- passes along a @'CursorEnv'@ that contains all the information we need to
 -- perform the lower-level cursor operations.
-newtype CursorM k v a = CursorM {unCursorM :: ReaderT (CursorEnv k v) IO a}
+newtype CursorM k v mode a = CursorM {unCursorM :: ReaderT (CursorEnv k v) IO a}
   deriving stock (Functor)
   deriving newtype (Applicative, Monad)
   deriving newtype (MonadIO, MonadReader (CursorEnv k v), MonadThrow, MonadCatch)
 
 -- | Run a cursor monad in @'IO'@.
-runCursorM :: CursorM k v a -> CursorEnv k v -> IO a
+--
+-- Note: this function ignores the type-level @mode@ information, which tracks
+-- whether the cursor is performing @'ReadOnly'@ or @'ReadWrite'@ operations.
+-- The user of this function should take care to provide a @'CursorEnv'@ with a
+-- cursor pointer that is compatible with this @mode@. A safer alternative is to
+-- use @'runCursorAsTransaction'@ or @'runCursorAsTransaction''@ in combination
+-- with one of the @'Transaction'@ runners (like @'readWriteTransaction'@).
+runCursorM :: CursorM k v mode a -> CursorEnv k v -> IO a
 runCursorM cm = runReaderT (unCursorM cm)
 
 -- | Default runner for running a cursor monad as a @'Transaction'@.
@@ -129,7 +138,7 @@ runCursorM cm = runReaderT (unCursorM cm)
 -- that is used to peek/poke pointers to keys and values.
 runCursorAsTransaction ::
      (Serialise k, Serialise v)
-  => CursorM k v a      -- ^ The cursor monad to run.
+  => CursorM k v mode a -- ^ The cursor monad to run.
   -> Database k v       -- ^ The database to run the cursor monad in.
   -> Transaction mode a
 runCursorAsTransaction cm (Db _ dbi) = Txn $ \txn ->
@@ -149,7 +158,7 @@ runCursorAsTransaction cm (Db _ dbi) = Txn $ \txn ->
 -- This runner requires an explicit @'PeekPoke'@ record that is used to
 -- peek/poke pointers to keys and values.
 runCursorAsTransaction' ::
-     CursorM k v a      -- ^ The cursor monad to run.
+     CursorM k v mode a -- ^ The cursor monad to run.
   -> Database k v       -- ^ The database to run the cursor monad in.
   -> PeekPoke k v       -- ^ Peek and poke functions for values of type @k@
                         --   and @v@.
@@ -159,9 +168,10 @@ runCursorAsTransaction' cm (Db _ dbi) pp = Txn $ \txn ->
     alloca $ \vptr ->
       withCursor txn dbi (\c -> runCursorM cm (CursorEnv c kptr vptr pp))
 
-type CursorConstraints m k v = (
-    MonadIO m
-  , MonadReader (CursorEnv k v) m
+type CursorConstraints :: (Type -> Type -> Type) -> Type -> Type -> Type -> Constraint
+type CursorConstraints m k v mode = (
+    MonadIO (m mode)
+  , MonadReader (CursorEnv k v) (m mode)
   )
 
 {-------------------------------------------------------------------------------
@@ -169,28 +179,28 @@ type CursorConstraints m k v = (
 -------------------------------------------------------------------------------}
 
 -- | Read the key at the key pointer.
-cpeekKey :: CursorConstraints m k v => m k
+cpeekKey :: CursorConstraints m k v mode => m mode k
 cpeekKey = do
   kPeek <- asks (kPeek . pp)
   kPtr <- asks kPtr
   liftIO $ kPeek kPtr
 
 -- | Read the value at the value pointer.
-cpeekValue :: CursorConstraints m k v => m v
+cpeekValue :: CursorConstraints m k v mode => m mode v
 cpeekValue = do
   vPeek <- asks (vPeek . pp)
   vPtr <- asks vPtr
   liftIO $ vPeek vPtr
 
 -- | Write a key at the key pointer.
-cpokeKey :: CursorConstraints m k v => k -> m ()
+cpokeKey :: CursorConstraints m k v mode => k -> m mode ()
 cpokeKey k = do
   kPoke <- asks (kPoke . pp)
   kPtr <- asks kPtr
   liftIO $ kPoke kPtr k
 
 -- | Write a value at the value pointer.
-cpokeValue :: CursorConstraints m k v => v -> m ()
+cpokeValue :: CursorConstraints m k v mode => v -> m mode ()
 cpokeValue v = do
   vPoke <- asks (vPoke . pp)
   vPtr <- asks vPtr
@@ -221,7 +231,7 @@ errCursorOpNotSupported op =
 --
 -- http://www.lmdb.tech/doc/group__mdb.html#ga1206b2af8b95e7f6b0ef6b28708c9127
 -- http://www.lmdb.tech/doc/group__mdb.html#ga48df35fb102536b32dfbb801a47b4cb0
-cgetG :: CursorConstraints m k v => MDB_cursor_op -> m (Maybe (k, v))
+cgetG :: CursorConstraints m k v mode => MDB_cursor_op -> m mode (Maybe (k, v))
 cgetG op = do
   r <- ask
   found <- liftIO $ mdb_cursor_get' op (cursor r) (kPtr r) (vPtr r)
@@ -233,71 +243,71 @@ cgetG op = do
     pure Nothing
 
 -- | Like @'cgetG'@, but throws away the result.
-cgetG_ :: CursorConstraints m k v => MDB_cursor_op -> m ()
+cgetG_ :: CursorConstraints m k v mode => MDB_cursor_op -> m mode ()
 cgetG_ = void . cgetG
 
-cgetFirst :: CursorConstraints m k v => m (Maybe (k, v))
+cgetFirst :: CursorConstraints m k v mode => m mode (Maybe (k, v))
 cgetFirst = cgetG MDB_FIRST
 
 -- TODO(jdral): sorted duplicates not supported yet.
-_cgetFirstDup :: CursorConstraints m k v => m (Maybe (k, v))
+_cgetFirstDup :: CursorConstraints m k v mode => m mode (Maybe (k, v))
 _cgetFirstDup  = errCursorOpNotSupported MDB_FIRST_DUP
 
 -- TODO(jdral): sorted duplicates not supported yet.
-_cgetBoth :: CursorConstraints m k v => m ()
+_cgetBoth :: CursorConstraints m k v mode => m mode ()
 _cgetBoth = errCursorOpNotSupported MDB_GET_BOTH
 
 -- TODO(jdral): sorted duplicates not supported yet.
-_cgetBothRange :: CursorConstraints m k v => m ()
+_cgetBothRange :: CursorConstraints m k v mode => m mode ()
 _cgetBothRange = errCursorOpNotSupported MDB_GET_BOTH_RANGE
 
-cgetCurrent :: CursorConstraints m k v => m (Maybe (k, v))
+cgetCurrent :: CursorConstraints m k v mode => m mode (Maybe (k, v))
 cgetCurrent = cgetG MDB_GET_CURRENT
 
 -- TODO(jdral): fixed-size, sorted duplicates not supported yet.
-_cgetMultiple :: CursorConstraints m k v => m ()
+_cgetMultiple :: CursorConstraints m k v mode => m mode ()
 _cgetMultiple  = errCursorOpNotSupported MDB_GET_MULTIPLE
 
-cgetLast :: CursorConstraints m k v => m (Maybe (k, v))
+cgetLast :: CursorConstraints m k v mode => m mode (Maybe (k, v))
 cgetLast = cgetG MDB_LAST
 
 -- TODO(jdral): sorted duplicates not supported yet.
-_cgetLastDup :: CursorConstraints m k v => m ()
+_cgetLastDup :: CursorConstraints m k v mode => m mode ()
 _cgetLastDup = errCursorOpNotSupported MDB_LAST_DUP
 
-cgetNext :: CursorConstraints m k v => m (Maybe (k, v))
+cgetNext :: CursorConstraints m k v mode => m mode (Maybe (k, v))
 cgetNext = cgetG MDB_NEXT
 
 -- TODO(jdral): sorted duplicates not supported yet.
-_cgetNextDup :: CursorConstraints m k v => m ()
+_cgetNextDup :: CursorConstraints m k v mode => m mode ()
 _cgetNextDup = errCursorOpNotSupported MDB_NEXT_DUP
 
 -- TODO(jdral): fixed-size, sorted duplicates not supported yet.
-_cgetNextMultiple :: CursorConstraints m k v => m ()
+_cgetNextMultiple :: CursorConstraints m k v mode => m mode ()
 _cgetNextMultiple = errCursorOpNotSupported MDB_NEXT_MULTIPLE
 
-cgetNextNoDup :: CursorConstraints m k v => m (Maybe (k, v))
+cgetNextNoDup :: CursorConstraints m k v mode => m mode (Maybe (k, v))
 cgetNextNoDup = cgetG MDB_NEXT_NODUP
 
-cgetPrev :: CursorConstraints m k v => m (Maybe (k, v))
+cgetPrev :: CursorConstraints m k v mode => m mode (Maybe (k, v))
 cgetPrev = cgetG MDB_PREV
 
 -- TODO(jdral): sorted duplicates not supported yet.
-_cgetPrevDup :: CursorConstraints m k v => m ()
+_cgetPrevDup :: CursorConstraints m k v mode => m mode ()
 _cgetPrevDup = errCursorOpNotSupported MDB_PREV_DUP
 
-cgetPrevNoDup :: CursorConstraints m k v => m (Maybe (k, v))
+cgetPrevNoDup :: CursorConstraints m k v mode => m mode (Maybe (k, v))
 cgetPrevNoDup = cgetG MDB_PREV_NODUP
 
-cgetSet :: CursorConstraints m k v => k -> m ()
+cgetSet :: CursorConstraints m k v mode => k -> m mode ()
 cgetSet k = cpokeKey k >> cgetG_ MDB_SET
 
-cgetSetKey :: CursorConstraints m k v => k -> m (Maybe (k, v))
+cgetSetKey :: CursorConstraints m k v mode => k -> m mode (Maybe (k, v))
 cgetSetKey k = cpokeKey k >> cgetG MDB_SET_KEY
 
 -- | @'cgetSetRange' k@ positions the cursor at the first key greater than or
 -- equal to @k@. Return key + data.
-cgetSetRange :: CursorConstraints m k v => k -> m (Maybe (k, v))
+cgetSetRange :: CursorConstraints m k v mode => k -> m mode (Maybe (k, v))
 cgetSetRange k = cpokeKey k >> cgetG MDB_SET_RANGE
 
 {-------------------------------------------------------------------------------
@@ -339,7 +349,9 @@ compileCPutFlag = compileWriteFlags . toList . fmap fromCPutFlag
 -- @'cputCurrent'@ and @'cputNoOverwrite'@ instead.
 --
 -- http://www.lmdb.tech/doc/group__mdb.html#ga1f83ccb40011837ff37cc32be01ad91e
-cputG :: CursorConstraints m k v => Maybe CPutFlag -> k -> v -> m Bool
+cputG ::
+     CursorConstraints m k v ReadWrite
+  => Maybe CPutFlag -> k -> v -> m ReadWrite Bool
 cputG flag k v = do
   r <- ask
   cpokeKey k
@@ -347,32 +359,40 @@ cputG flag k v = do
   liftIO $
     mdb_cursor_put_ptr' (compileCPutFlag flag) (cursor r) (kPtr r) (vPtr r)
 
-cput :: CursorConstraints m k v => k -> v -> m Bool
+cput ::
+     CursorConstraints m k v ReadWrite
+  => k -> v -> m ReadWrite Bool
 cput = cputG   Nothing
 
-cputCurrent :: CursorConstraints m k v => k -> v -> m Bool
+cputCurrent ::
+     CursorConstraints m k v ReadWrite
+  => k -> v -> m ReadWrite Bool
 cputCurrent = cputG $ Just CPF_MDB_CURRENT
 
 -- TODO(jdral): sorted duplicates not supported yet.
-_cputNoDupData :: CursorConstraints m k v => m ()
+_cputNoDupData :: CursorConstraints m k v ReadWrite => m ReadWrite ()
 _cputNoDupData = errPutFlagNotSupported CPF_MDB_NODUPDATA
 
-cputNoOverwrite :: CursorConstraints m k v => k -> v -> m Bool
+cputNoOverwrite ::
+     CursorConstraints m k v ReadWrite
+  => k -> v -> m ReadWrite Bool
 cputNoOverwrite = cputG $ Just CPF_MDB_NOOVERWRITE
 
 -- TODO(jdral): not yet supported, needs special handling.
-_cputReserve :: CursorConstraints m k v => m ()
+_cputReserve :: CursorConstraints m k v ReadWrite => m ReadWrite ()
 _cputReserve = errPutFlagNotSupported CPF_MDB_RESERVE
 
-cputAppend :: CursorConstraints m k v => k -> v -> m Bool
+cputAppend ::
+     CursorConstraints m k v ReadWrite
+  => k -> v -> m ReadWrite Bool
 cputAppend = cputG $ Just CPF_MDB_APPEND
 
 -- TODO(jdral): sorted duplicates not supported yet.
-_cputAppendDup :: CursorConstraints m k v => m ()
+_cputAppendDup :: CursorConstraints m k v ReadWrite => m ReadWrite ()
 _cputAppendDup = errPutFlagNotSupported CPF_MDB_APPENDDUP
 
 -- TODO(jdral): fixed-size, sorted duplicates not supported yet.
-_cputMultiple :: CursorConstraints m k v => m ()
+_cputMultiple :: CursorConstraints m k v ReadWrite => m ReadWrite ()
 _cputMultiple = errPutFlagNotSupported CPF_MDB_MULTIPLE
 
 {-------------------------------------------------------------------------------
@@ -401,17 +421,17 @@ compileCDelFlag = compileWriteFlags . toList . fmap fromCDelFlag
 -- instead.
 --
 -- http://www.lmdb.tech/doc/group__mdb.html#ga26a52d3efcfd72e5bf6bd6960bf75f95
-cdelG :: CursorConstraints m k v => Maybe CDelFlag -> m ()
+cdelG :: CursorConstraints m k v ReadWrite => Maybe CDelFlag -> m ReadWrite ()
 cdelG flag = do
   r <- ask
   if kPtr r == nullPtr then error "e" else pure ()
   liftIO $ mdb_cursor_del' (compileCDelFlag flag) (cursor r)
 
-cdel :: CursorConstraints m k v => m ()
+cdel :: CursorConstraints m k v ReadWrite => m ReadWrite ()
 cdel = cdelG Nothing
 
 -- TODO(jdral): sorted duplicates not supported yet.
-_cdelNoDupData :: CursorConstraints m k v => m ()
+_cdelNoDupData :: CursorConstraints m k v ReadWrite => m ReadWrite ()
 _cdelNoDupData = errDelFlagNotSupported CDF_MDB_NODUPDATA
 
 {-------------------------------------------------------------------------------
@@ -420,17 +440,17 @@ _cdelNoDupData = errDelFlagNotSupported CDF_MDB_NODUPDATA
 
 -- | Strict fold over the full database.
 forEach ::
-     forall m a k v.
-     CursorConstraints m k v
+     forall m a k v mode.
+     CursorConstraints m k v mode
   => MDB_cursor_op
   -> MDB_cursor_op
   -> (a -> k -> v -> a)
   -> a
-  -> m a
+  -> m mode a
 forEach first next f z = do
     go first z
   where
-    go :: MDB_cursor_op -> a -> m a
+    go :: MDB_cursor_op -> a -> m mode a
     go op acc = do
       x <- cgetG op
       case x of
@@ -440,24 +460,24 @@ forEach first next f z = do
 
 -- | Strict left fold over the full database.
 forEachForward ::
-     CursorConstraints m k v
+     CursorConstraints m k v mode
   => (a -> k -> v -> a)
   -> a
-  -> m a
+  -> m mode a
 forEachForward  = forEach MDB_FIRST MDB_NEXT
 
 -- | Strict right fold over the full database.
 forEachBackward ::
-     CursorConstraints m k v
+     CursorConstraints m k v mode
   => (k -> v -> a -> a)
   -> a
-  -> m a
+  -> m mode a
 forEachBackward f = forEach MDB_LAST MDB_PREV f'
   where f' z k v = f k v z
 
 cgetAll ::
-     (CursorConstraints m k v, Ord k)
-  => m (Map k v)
+     (CursorConstraints m k v mode, Ord k)
+  => m mode (Map k v)
 cgetAll = forEachForward (\acc k v -> Map.insert k v acc) mempty
 
 data Bound = Exclusive | Inclusive
@@ -482,12 +502,12 @@ data FoldRange k v = FoldRange {
 --
 -- Note: This is a strict left fold.
 cfoldM ::
-     forall m b k v.
-     (CursorConstraints m k v, Ord k)
-  => (b -> k -> v -> m b)
+     forall m b k v mode.
+     (CursorConstraints m k v mode, Ord k)
+  => (b -> k -> v -> (m mode) b)
   -> b
   -> FoldRange k v
-  -> m b
+  -> m mode b
 cfoldM f z FoldRange{lowerBound = lb, keysToFold = n}
     | n <= 0    = pure z
     | otherwise = do
@@ -500,13 +520,13 @@ cfoldM f z FoldRange{lowerBound = lb, keysToFold = n}
             !z'' <- foldM f' z' [1..n-1]
             pure z''
   where
-    cgetInitial :: m (Maybe (k, v))
+    cgetInitial :: m mode (Maybe (k, v))
     cgetInitial = maybe cgetFirst (uncurry cgetSetRange') lb
 
     -- Like @'cgetSetRange'@, but may skip the first read key if the the lower
     -- bound is exclusive and @k@ is the first key that was read from the
     -- database.
-    cgetSetRange' :: k -> Bound -> m (Maybe (k, v))
+    cgetSetRange' :: k -> Bound -> m mode (Maybe (k, v))
     cgetSetRange' k b = do
       k2vMay <- cgetSetRange k
       case k2vMay of
@@ -515,7 +535,7 @@ cfoldM f z FoldRange{lowerBound = lb, keysToFold = n}
                      , Exclusive <- b -> cgetNext
                      | otherwise      -> pure $ Just (k2, v)
 
-    f' :: b -> Int -> m b
+    f' :: b -> Int -> m mode b
     f' !acc _ = do
       kvMay <- cgetNext
       case kvMay of
@@ -528,12 +548,12 @@ cfoldM f z FoldRange{lowerBound = lb, keysToFold = n}
 -- Uses `cfoldM` to perform the range read using a monadic fold. See @'cfoldM'@
 -- and @'FoldRange'@ for specifics on how ranges are folded.
 cgetMany ::
-     forall m k v.
-     (CursorConstraints m k v, Ord k)
+     forall m k v mode.
+     (CursorConstraints m k v mode, Ord k)
   => Maybe (k, Bound)
   -> Int
-  -> m (Map k v)
+  -> m mode (Map k v)
 cgetMany lbMay n = cfoldM f Map.empty (FoldRange lbMay n)
   where
-    f :: Map k v -> k -> v -> m (Map k v)
+    f :: Map k v -> k -> v -> m mode (Map k v)
     f m k v = pure $ Map.insert k v m

--- a/test-cursors/Test/Database/LMDB/Simple/Cursor.hs
+++ b/test-cursors/Test/Database/LMDB/Simple/Cursor.hs
@@ -1,4 +1,3 @@
-
 module Test.Database.LMDB.Simple.Cursor  where
 
 import           Test.Tasty


### PR DESCRIPTION
Transactions run in one of two modes: read-only and read-write. Environments can also be read-only or read-write.

```haskell
data ReadWrite
data ReadOnly

newtype Environment mode = {- ... -}
newtype Transaction mode a = {- ... -}
```

When we run a transaction in an environment, the mode of the transaction must be a sub-mode of the environment's mode.

```haskell
type family SubMode a b :: Constraint where
  SubMode a ReadWrite = a ~ ReadWrite
  SubMode a ReadOnly  = ()
```

This ensures that read-write transactions can only be run in read-write environments. Read-only transactions can be run in either read-only or read-write environments.

The current cursor monad does not currently keep track of any type-level information about modes. This means that a cursor that writes to the database can run in both read-only and read-write mode. This PR adds the mode parameter to the cursor monad, such that read-write cursor monads can only be run as read-write transactions.