### PR TITLE
Make modes a data kind

### DIFF
--- a/bench/Bench/Utils.hs
+++ b/bench/Bench/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}

--- a/cardano-lmdb-simple.cabal
+++ b/cardano-lmdb-simple.cabal
@@ -45,6 +45,14 @@ library
                      , serialise >= 0.2 && < 0.3
                      , unliftio-core
   ghc-options:         -Wall -Wno-name-shadowing -Wno-unused-do-bind
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+                       -Wno-unticked-promoted-constructors
   default-language:    Haskell2010
   default-extensions:  Trustworthy
   other-extensions:    ConstraintKinds
@@ -74,6 +82,7 @@ test-suite test-cursors
                      , temporary
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
                        -Werror
+                       -Wno-unticked-promoted-constructors
   default-language:    Haskell2010
 
 benchmark bench
@@ -97,6 +106,7 @@ benchmark bench
                      , temporary
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
                        -with-rtsopts=-A32m -Werror
+                       -Wno-unticked-promoted-constructors
   default-language:    Haskell2010
 
 test-suite sample
@@ -106,6 +116,7 @@ test-suite sample
   build-depends:       base
                      , cardano-lmdb-simple
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+                       -Wno-unticked-promoted-constructors
   default-language:    Haskell2010
 
 test-suite hspec
@@ -122,6 +133,7 @@ test-suite hspec
   build-tool-depends:  hspec-discover:hspec-discover
   ghc-options:         -Wall -Wno-unused-do-bind
                        -threaded -rtsopts -with-rtsopts=-N
+                       -Wno-unticked-promoted-constructors
   default-language:    Haskell2010
 
 benchmark criterion
@@ -134,4 +146,5 @@ benchmark criterion
                      , cardano-lmdb-simple
   ghc-options:         -Wall -Wno-name-shadowing
                        -threaded -rtsopts -with-rtsopts=-N
+                       -Wno-unticked-promoted-constructors
   default-language:    Haskell2010

--- a/changelog.d/20230222_112703_joris_mode_as_datakind.md
+++ b/changelog.d/20230222_112703_joris_mode_as_datakind.md
@@ -1,0 +1,30 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Breaking
+
+- Represent transaction/environment modes as a `Mode` data kind instead of as
+  `Type`s. As a consequence, restrict types that are parameterised by modes
+  (such as `Transaction`, `Environment`, `TransactionHandle` and `CursorM`) to
+  `Mode`-kinded type arguments. e.g.,
+  ```haskell
+  type Transaction :: Mode -> Type -> Type
+  ```
+- Rename `Mode` type class to `IsMode`. Its kind is restricted to `Mode`-kinded
+  types.
+

--- a/src/Database/LMDB/Simple.hs
+++ b/src/Database/LMDB/Simple.hs
@@ -1,7 +1,10 @@
-
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RankNTypes #-}
+
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
 {-|
 Module      : Database.LMDB.Simple
 Description : Simple Haskell API for LMDB
@@ -76,9 +79,7 @@ module Database.LMDB.Simple
   , clear
 
     -- * Access modes
-  , ReadWrite
-  , ReadOnly
-  , Mode
+  , Mode (..)
   , SubMode
   ) where
 
@@ -133,9 +134,8 @@ import Database.LMDB.Raw
   )
 
 import Database.LMDB.Simple.Internal
-  ( ReadWrite
-  , ReadOnly
-  , Mode
+  ( Mode (..)
+  , IsMode
   , SubMode
   , Environment (Env)
   , Transaction (Txn)
@@ -218,14 +218,14 @@ defaultLimits = Limits
 -- An environment opened in 'ReadOnly' mode may still modify the reader lock
 -- table (except when the filesystem is read-only, in which case no locks are
 -- used).
-openEnvironment :: forall mode. Mode mode => FilePath -> Limits -> IO (Environment mode)
+openEnvironment :: forall mode. IsMode mode => FilePath -> Limits -> IO (Environment mode)
 openEnvironment = openEnvironmentWithFlags flags where
   flags = [MDB_RDONLY | isReadOnlyEnvironment (undefined :: Environment mode)]
 
 
 -- | As 'openEnvironment' but using explicit LMDB environment flags.
 -- No effort is made to validate the flags.
-openEnvironmentWithFlags :: Mode mode => [MDB_EnvFlag] -> FilePath -> Limits -> IO (Environment mode)
+openEnvironmentWithFlags :: [MDB_EnvFlag] -> FilePath -> Limits -> IO (Environment mode)
 openEnvironmentWithFlags flags path limits = do
   env <- mdb_env_create
 
@@ -233,7 +233,7 @@ openEnvironmentWithFlags flags path limits = do
   mdb_env_set_maxdbs     env (maxDatabases limits)
   mdb_env_set_maxreaders env (maxReaders   limits)
 
-  let environ = Env env :: Mode mode => Environment mode
+  let environ = Env env :: Environment mode
 
   r <- tryJust (guard . isNotDirectoryError) $ mdb_env_open env path flags
   case r of
@@ -255,13 +255,13 @@ runInBoundThread' action = withAsyncBound action wait
 
 -- | Closes an open envrionment. After calling this function, the
 -- environment should *not* be used again.
-closeEnvironment :: Mode mode => Environment mode -> IO ()
+closeEnvironment :: Environment mode -> IO ()
 closeEnvironment (Env mdb_env) = runInBoundThread' $ mdb_env_close mdb_env
 
 -- | Closes an open envrionment as with 'closeEnvironment'. After calling this function, the
 -- environment should *not* be used again.
 -- Does not return until the environment is closed.
-closeEnvironmentBlocking :: Mode mode => Environment mode -> IO ()
+closeEnvironmentBlocking :: Environment mode -> IO ()
 closeEnvironmentBlocking (Env mdb_env) = do
   mv <- newEmptyMVar
   runInBoundThread' $ do
@@ -311,7 +311,7 @@ clearStaleReaders (Env env) = mdb_reader_check env
 -- transactions, and thus the database can grow quickly. 'ReadWrite'
 -- transactions prevent other 'ReadWrite' transactions, since writes are
 -- serialized.
-transaction :: (Mode tmode, SubMode emode tmode)
+transaction :: (IsMode tmode, SubMode emode tmode)
             => Environment emode -> Transaction tmode a -> IO a
 transaction (Env env) tx@(Txn tf)
   | isReadOnlyTransaction tx = run True
@@ -391,7 +391,7 @@ transactionWithRunInIO inner = Txn $ \txn -> inner (\(Txn tf) -> tf txn)
 --
 -- You can (and should) retain the database handle returned by this action for
 -- use in future transactions.
-getDatabase :: Mode mode => Maybe String -> Transaction mode (Database k v)
+getDatabase :: IsMode mode => Maybe String -> Transaction mode (Database k v)
 getDatabase name = tx
   where tx = Txn $ \txn -> Db (mdb_txn_env txn) <$> mdb_dbi_open' txn name flags
         flags = [MDB_CREATE | isReadWriteTransaction tx]

--- a/src/Database/LMDB/Simple/DBRef.hs
+++ b/src/Database/LMDB/Simple/DBRef.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 
 -- | This module provides a mutable variable 'DBRef' that is similar in
 -- concept to 'Data.IORef.IORef' except that it is tied to a particular key
@@ -32,8 +33,7 @@ import Database.LMDB.Simple.Internal
   ( Environment (..)
   , Transaction (..)
   , Database (..)
-  , ReadWrite
-  , ReadOnly
+  , Mode (..)
   , Serialise
   , serialiseBS
   , getBS

--- a/src/Database/LMDB/Simple/Extra.hs
+++ b/src/Database/LMDB/Simple/Extra.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 
 -- | This module exports many functions for querying and modifying LMDB
 -- databases using common idioms (albeit in monadic form).
@@ -70,7 +71,7 @@ import Database.LMDB.Raw
   )
 
 import Database.LMDB.Simple.Internal
-  ( ReadWrite
+  ( Mode (ReadWrite)
   , Transaction (Txn)
   , Database (Db)
   , Serialise

--- a/src/Database/LMDB/Simple/Internal.hs
+++ b/src/Database/LMDB/Simple/Internal.hs
@@ -129,7 +129,8 @@ instance IsMode ReadOnly  where
 
 -- | Both read-only and read-write transactions can run in a read-write
 -- environment, but read-only transactions can only run in read-only
--- environments.
+-- environments. @mode1@ would be the environment's mode, and @mode2@ would be
+-- the transaction's mode.
 type SubMode :: Mode -> Mode -> Constraint
 type family SubMode mode1 mode2 where
   SubMode mode1 ReadWrite = mode1 ~ ReadWrite

--- a/test-cursors/Test/Database/LMDB/Simple/Cursor/Lockstep.hs
+++ b/test-cursors/Test/Database/LMDB/Simple/Cursor/Lockstep.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}

--- a/test/Harness.hs
+++ b/test/Harness.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 
 module Harness
   ( setup

--- a/test/criterion.hs
+++ b/test/criterion.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 
 module Main where
 


### PR DESCRIPTION
https://github.com/input-output-hk/lmdb-simple/pull/10#discussion_r1109926816 suggested documenting what the LMDB `Mode`s are that can be associated with transactions and environments. This PR documents modes, but also proposes a change to their implementation, representing them as `DataKind`s instead of empty types. They change from ...
```haskell
data ReadWrite
data ReadOnly
```
... to ...
```haskell
data Mode = ReadWrite | ReadOnly
```

This has some advantages and disadvantages:

* Advantage: We can now restrict mode type parameters to be of kind `Mode`, preventing arbitrary types from being used as parameters. 
  ```haskell
  type Environment :: Mode -> Type
  type Transaction :: Mode -> Type -> Type
  ```
  Before this change, `ReadWrite :: Type` and `ReadOnly :: Type`, so we could have written `Environment Word64`.
* Advantage: For the same reason, we can remove some constraints that have become redundant (the `Mode`/`IsMode` constraint).
* Disadvantage: Downstream code has to enable `DataKinds`.
* Disadvantage: Downstream code has to disable unticked promoted constructor warnings, or use ticked promoted constructors.