### PR TITLE
Small test for read-only transaction handles

### DIFF
--- a/cardano-lmdb-simple.cabal
+++ b/cardano-lmdb-simple.cabal
@@ -65,6 +65,7 @@ test-suite test-cursors
   other-modules:       Test.Database.LMDB.Simple.Cursor
                        Test.Database.LMDB.Simple.Cursor.Lockstep
                        Test.Database.LMDB.Simple.Cursor.Lockstep.Mock
+                       Test.Database.LMDB.Simple.TransactionHandle
   build-depends:       base
                      , cardano-lmdb
                      , cardano-lmdb-simple
@@ -81,7 +82,6 @@ test-suite test-cursors
                      , tasty-quickcheck
                      , temporary
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
-                       -Werror
                        -Wno-unticked-promoted-constructors
   default-language:    Haskell2010
 

--- a/changelog.d/20230302_135133_joris_14_read_only_transaction_handle_test.md
+++ b/changelog.d/20230302_135133_joris_14_read_only_transaction_handle_test.md
@@ -1,0 +1,21 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Breaking
+
+- Remove definitions for read-write transaction handles from the exports list of the `TransactionHandle` module. See [issue 14](https://github.com/input-output-hk/lmdb-simple/issues/14#issuecomment-1446841800).

--- a/src/Database/LMDB/Simple/TransactionHandle.hs
+++ b/src/Database/LMDB/Simple/TransactionHandle.hs
@@ -38,12 +38,8 @@ module Database.LMDB.Simple.TransactionHandle (
     TransactionHandle
   , abort
   , commit
-  , _new
   , newReadOnly
-  , _newReadWrite
-  , _submit
   , submitReadOnly
-  , _submitReadWrite
   ) where
 
 import           Control.Concurrent.MVar

--- a/test-cursors/Main.hs
+++ b/test-cursors/Main.hs
@@ -2,7 +2,8 @@ module Main where
 
 import           Test.Tasty
 
-import qualified Test.Database.LMDB.Simple.Cursor as Test.Cursor
+import qualified Test.Database.LMDB.Simple.Cursor            as Test.Cursor
+import qualified Test.Database.LMDB.Simple.TransactionHandle as Test.TransactionHandle
 
 main :: IO ()
 main = defaultMain $ testGroup "test-cursors" [
@@ -11,6 +12,7 @@ main = defaultMain $ testGroup "test-cursors" [
             testGroup "LMDB" [
                 testGroup "Simple" [
                     Test.Cursor.tests
+                  , Test.TransactionHandle.tests
                   ]
               ]
           ]

--- a/test-cursors/Test/Database/LMDB/Simple/TransactionHandle.hs
+++ b/test-cursors/Test/Database/LMDB/Simple/TransactionHandle.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Database.LMDB.Simple.TransactionHandle where
+
+import           System.IO.Temp
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Database.LMDB.Simple
+import           Database.LMDB.Simple.TransactionHandle
+
+tests :: TestTree
+tests = testGroup "TransactionHandle" [
+    testProperty "prop_simpleScenario" prop_simpleScenario
+  ]
+
+-- | A simple test for performing reads through a transaction handle.
+-- Transaction handles do not see the effects of writes that are comitted after
+-- the transaction handle is created.
+prop_simpleScenario :: Property
+prop_simpleScenario = once $ monadicIO $ run $
+  withSystemTempDirectory "prop_simpleScenario" $ \fp -> do
+    env <- openEnvironment @ReadWrite fp defaultLimits
+
+    -- Insert dummy entries into the database.
+    readWriteTransaction env $ do
+      db <- getDatabase @ReadWrite @Int @Int Nothing
+      put db 1 (Just 1)
+      put db 2 (Just 2)
+
+    th <- newReadOnly env
+
+    -- Delete the dummy entries in the database. The transaction handle should
+    -- not see this effect.
+    readWriteTransaction env $ do
+      db <- getDatabase @ReadWrite @Int @Int Nothing
+      put db 1 Nothing
+      put db 2 Nothing
+
+    (x, y) <- submitReadOnly th $ do
+      db <- getDatabase @ReadOnly @Int @Int Nothing
+      x <- get db 2
+      y <- get db 1
+      pure (x, y)
+    commit th
+
+    closeEnvironmentBlocking env
+
+    pure (x == Just 2 && y == Just 1)


### PR DESCRIPTION
Part of #14.

This PR adds a small test for read-only transaction handles. Furthermore, we declare transaction handle functions that run in read-write mode to be internal, since we can not currently implement them (see https://github.com/input-output-hk/lmdb-simple/issues/14#issuecomment-1446841800).