### PR TITLE
Add comment why we currently can't implement read-write transaction handles.

### DIFF
--- a/src/Database/LMDB/Simple/TransactionHandle.hs
+++ b/src/Database/LMDB/Simple/TransactionHandle.hs
@@ -33,6 +33,14 @@
   Note on terminology: whenever we speak of a transaction handle, we refer to a
   @'TransactionHandle'@, unless we say it is an /internal (LMDB)/ transaction
   handle, in which case we refer to an @'MDB_txn'@.
+
+  TODO: We can currently not implement the submission of read-write
+  transactions, because the lower-level Haskell bindings are set up in such a
+  way that the internal 'MDB_txn' should be created and completed in a single
+  bound Haskell thread (see 'mdb_txn_begin'). This is not compatible with the
+  TransactionHandle use case, where the 'MDB_txn' is created separately from
+  where it is used. As such, only 'ReadOnly' transactions are provided by this
+  module.
 -}
 module Database.LMDB.Simple.TransactionHandle (
     TransactionHandle

--- a/src/Database/LMDB/Simple/TransactionHandle.hs
+++ b/src/Database/LMDB/Simple/TransactionHandle.hs
@@ -34,13 +34,13 @@
   @'TransactionHandle'@, unless we say it is an /internal (LMDB)/ transaction
   handle, in which case we refer to an @'MDB_txn'@.
 
-  TODO: We can currently not implement the submission of read-write
-  transactions, because the lower-level Haskell bindings are set up in such a
-  way that the internal 'MDB_txn' should be created and completed in a single
-  bound Haskell thread (see 'mdb_txn_begin'). This is not compatible with the
-  TransactionHandle use case, where the 'MDB_txn' is created separately from
-  where it is used. As such, only 'ReadOnly' transactions are provided by this
-  module.
+  We can currently not implement the submission of read-write transactions,
+  because the lower-level Haskell bindings are set up in such a way that the
+  internal 'MDB_txn' should be created and completed in a single bound Haskell
+  thread (see 'mdb_txn_begin' to see why this is imposed by LMDB itself). This
+  is not compatible with the TransactionHandle use case, where the 'MDB_txn' is
+  created separately from where it is used. As such, only 'ReadOnly'
+  transactions are provided by this module.
 -}
 module Database.LMDB.Simple.TransactionHandle (
     TransactionHandle


### PR DESCRIPTION
Closes #14.

We can currently not implement read-write transaction handles because of how the lower-level haskell bindings in `haskell-lmdb` are set up. This PR adds a comment to the `TransactionHandle` module that explains the reasoning, such that we can close #14.