### PR TITLE
Revert release of `cardano-lmdb-simple-0.6.1.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## 0.6.1.2 — 2023-03-22
-
-### Patch
-
-- Relax upper bound on `bytestring` from `<0.12` to `<0.13`
-
 ## 0.6.1.1 — 2023 08-01
 
 ### Patch

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![handbook](https://img.shields.io/badge/policy-Cardano%20Engineering%20Handbook-informational)](https://input-output-hk.github.io/cardano-engineering-handbook)
-[![Haskell CI](https://img.shields.io/github/actions/workflow/status/input-output-hk/ldmb-simple/haskell.yml?label=Build)](https://github.com/input-output-hk/lmdb-simple/actions/workflows/haskell.yml)
+[![Haskell CI](https://img.shields.io/github/actions/workflow/status/input-output-hk/lmdb-simple/haskell.yml?label=Build&style=for-the-badge)](https://github.com/input-output-hk/lmdb-simple/actions/workflows/haskell.yml)
+[![handbook](https://img.shields.io/badge/policy-Cardano%20Engineering%20Handbook-informational?style=for-the-badge)](https://input-output-hk.github.io/cardano-engineering-handbook)
 
 # Input-Ouptut fork lmdb-simple
 

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/cabal.project
+++ b/cabal.project
@@ -11,9 +11,3 @@ repository cardano-haskell-packages
 
 packages:
   .
-
-source-repository-package
-  type: git
-  location: https://github.com/jasagredo/quickcheck-lockstep
-  tag: 883f2e54a495b6cca1c30cfafdcc70dc70ed6d0c
-  --sha256: 1309cs7p2zggq9klhd72c76xyinvi8vf2n8jxpbmibx2qbl9xr0d

--- a/cabal.project
+++ b/cabal.project
@@ -11,3 +11,9 @@ repository cardano-haskell-packages
 
 packages:
   .
+
+source-repository-package
+  type: git
+  location: https://github.com/jasagredo/quickcheck-lockstep
+  tag: 883f2e54a495b6cca1c30cfafdcc70dc70ed6d0c
+  --sha256: 1309cs7p2zggq9klhd72c76xyinvi8vf2n8jxpbmibx2qbl9xr0d

--- a/cardano-lmdb-simple.cabal
+++ b/cardano-lmdb-simple.cabal
@@ -37,7 +37,7 @@ library
 
   build-depends:       async
                      , base >= 4.7 && < 5
-                     , bytestring >= 0.10 && < 0.13
+                     , bytestring >= 0.10 && < 0.12
                      , containers
                      , exceptions
                      , cardano-lmdb >= 0.3.0.0

--- a/cardano-lmdb-simple.cabal
+++ b/cardano-lmdb-simple.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                cardano-lmdb-simple
-version:             0.6.1.2
+version:             0.6.1.1
 synopsis:            Simple API for LMDB
 description:         This package provides a simple API for using the
                      Lightning Memory-mapped Database (LMDB).

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,8 @@
+resolver: lts-20.7
+
+packages:
+- .
+
+extra-deps:
+  - git: https://github.com/input-output-hk/haskell-lmdb
+    commit: 08e5c1572e98e599d60bb24a7b2569879a35a7b1


### PR DESCRIPTION
Reverts #27 and 35a0959dab7ca9e17406ccac2099bf4002aa3f73.

There are test failures (#28, #29) that we have to address before we can release a new version of `cardano-lmdb-simple`